### PR TITLE
Misc fixes

### DIFF
--- a/common/src/main/java/net/creeperhost/equivalentexchange/api/EquivalentExchangeAPI.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/api/EquivalentExchangeAPI.java
@@ -15,6 +15,9 @@ import net.minecraft.world.level.block.state.BlockState;
 import java.text.NumberFormat;
 import java.util.*;
 
+import org.jetbrains.annotations.Nullable;
+
+
 public class EquivalentExchangeAPI
 {
     public static IEmcStorageHandler iEmcStorageHandler;
@@ -27,7 +30,7 @@ public class EquivalentExchangeAPI
     public static Map<RecipeType<?>, IEmcRecipeParser> PARSERS = new HashMap<>();
 
     @Deprecated
-    public static void registerInWorldTransmutationRecipe(BlockState input, BlockState output, BlockState altOutput)
+    public static void registerInWorldTransmutationRecipe(BlockState input, BlockState output, @Nullable BlockState altOutput)
     {
         InWorldTransmutation inWorldTransmutation = new InWorldTransmutation(input, output, altOutput);
         IN_WORLD_TRANSMUTATION_RECIPES.add(inWorldTransmutation);

--- a/common/src/main/java/net/creeperhost/equivalentexchange/api/recipe/InWorldTransmutation.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/api/recipe/InWorldTransmutation.java
@@ -1,5 +1,7 @@
 package net.creeperhost.equivalentexchange.api.recipe;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.world.level.block.state.BlockState;
 
 //TODO this should also be a recipe json at some point
@@ -8,9 +10,9 @@ public class InWorldTransmutation
 {
     BlockState input;
     BlockState result;
-    BlockState altResult;
+    @Nullable BlockState altResult;
 
-    public InWorldTransmutation(BlockState input, BlockState result, BlockState altResult)
+    public InWorldTransmutation(BlockState input, BlockState result, @Nullable BlockState altResult)
     {
         this.input = input;
         this.result = result;
@@ -27,7 +29,7 @@ public class InWorldTransmutation
         return result;
     }
 
-    public BlockState getAltResult()
+    public @Nullable BlockState getAltResult()
     {
         return altResult;
     }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/client/ClientEvents.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/client/ClientEvents.java
@@ -118,7 +118,7 @@ public class ClientEvents
             if(stack != null && !stack.isEmpty() && stack.getItem() instanceof ItemPhilosophersStone stone)
             {
                 int range = 5;
-                BlockHitResult lookingAt = VectorHelper.getLookingAt(minecraft.player, ClipContext.Fluid.NONE, range);
+                BlockHitResult lookingAt = VectorHelper.getLookingAt(minecraft.player, ClipContext.Fluid.SOURCE_ONLY, range);
                 BlockPos blockPos = lookingAt.getBlockPos();
                 if(minecraft.level.getBlockState(blockPos) != null && !minecraft.level.getBlockState(blockPos).isAir())
                 {

--- a/common/src/main/java/net/creeperhost/equivalentexchange/client/ClientEvents.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/client/ClientEvents.java
@@ -41,6 +41,8 @@ import net.minecraft.world.phys.BlockHitResult;
 
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 public class ClientEvents
 {
     public static void toolTipEvent(ItemStack stack, List<Component> components, TooltipFlag tooltipFlag)
@@ -127,7 +129,8 @@ public class ClientEvents
                     {
                         if(inWorldTransmutation.getInput() != null && inputState.equals(inWorldTransmutation.getInput()))
                         {
-                            BlockState out = minecraft.player.isShiftKeyDown() ? inWorldTransmutation.getAltResult() : inWorldTransmutation.getResult();
+                            @Nullable BlockState out = minecraft.player.isShiftKeyDown() ? inWorldTransmutation.getAltResult() : inWorldTransmutation.getResult();
+                            if (out == null) continue;
                             renderStack = new ItemStack(out.getBlock());
                             break;
                         }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
@@ -34,8 +34,12 @@ public class BlockOverlayRender
 
         MultiBufferSource.BufferSource buffer = mc.renderBuffers().bufferSource();
         int hitRange = 10;
-        BlockHitResult lookingAt = VectorHelper.getLookingAt(mc.player, ClipContext.Fluid.SOURCE_ONLY, hitRange);
-        if (mc.level.getBlockState(VectorHelper.getLookingAt(mc.player, hitRange).getBlockPos()) == Blocks.AIR.defaultBlockState())
+        BlockHitResult lookingAt = VectorHelper.getLookingAt(mc.player, item.getItem() instanceof ItemPhilosophersStone ? ClipContext.Fluid.SOURCE_ONLY : ClipContext.Fluid.NONE, hitRange);
+        if(item.getItem() instanceof IOverlayItem iOverlayItem)
+        {
+            if(iOverlayItem.excludedFromOverlay(mc.level.getBlockState(lookingAt.getBlockPos()))) return;
+        }
+        else if(mc.level.getBlockState(lookingAt.getBlockPos()) == Blocks.AIR.defaultBlockState())
         {
             return;
         }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
@@ -37,7 +37,7 @@ public class BlockOverlayRender
         BlockHitResult lookingAt = VectorHelper.getLookingAt(mc.player, item.getItem() instanceof ItemPhilosophersStone ? ClipContext.Fluid.SOURCE_ONLY : ClipContext.Fluid.NONE, hitRange);
         if(item.getItem() instanceof IOverlayItem iOverlayItem)
         {
-            if(iOverlayItem.excludedFromOverlay(mc.level.getBlockState(lookingAt.getBlockPos()))) return;
+            if(iOverlayItem.blockIgnored(mc.level.getBlockState(lookingAt.getBlockPos()))) return;
         }
         else if(mc.level.getBlockState(lookingAt.getBlockPos()) == Blocks.AIR.defaultBlockState())
         {

--- a/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
@@ -1,5 +1,6 @@
 package net.creeperhost.equivalentexchange.client.renders;
 
+import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
@@ -64,8 +65,13 @@ public class BlockOverlayRender
         poseStack.pushPose();
         poseStack.translate(-view.x(), -view.y(), -view.z());
 
-        VertexConsumer builder;
-        builder = buffer.getBuffer(RenderTypes.BlockOverlay);
+        RenderSystem.enableBlend();
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+        RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthMask(false);
+
+        VertexConsumer builder = buffer.getBuffer(RenderTypes.BlockOverlay);
 
         Color finalColor = color;
         coords.forEach((blockPos, blockState) ->
@@ -82,8 +88,10 @@ public class BlockOverlayRender
         });
 
         poseStack.popPose();
-        RenderSystem.disableDepthTest();
         buffer.endBatch(RenderTypes.BlockOverlay);
+
+        RenderSystem.depthMask(true);
+        RenderSystem.disableBlend();
     }
 
     public static void render(Matrix4f matrix, VertexConsumer builder, BlockPos pos, Color color)

--- a/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/client/renders/BlockOverlayRender.java
@@ -33,7 +33,7 @@ public class BlockOverlayRender
 
         MultiBufferSource.BufferSource buffer = mc.renderBuffers().bufferSource();
         int hitRange = 10;
-        BlockHitResult lookingAt = VectorHelper.getLookingAt(mc.player, ClipContext.Fluid.NONE, hitRange);
+        BlockHitResult lookingAt = VectorHelper.getLookingAt(mc.player, ClipContext.Fluid.SOURCE_ONLY, hitRange);
         if (mc.level.getBlockState(VectorHelper.getLookingAt(mc.player, hitRange).getBlockPos()) == Blocks.AIR.defaultBlockState())
         {
             return;

--- a/common/src/main/java/net/creeperhost/equivalentexchange/impl/TransmutationTableHandler.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/impl/TransmutationTableHandler.java
@@ -10,24 +10,28 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 public class TransmutationTableHandler
 {
-    private static final HashMap<String, TransmutationInventory> INVENTORIES = new HashMap<>();
+    private static final HashMap<UUID, TransmutationInventory> SERVER_INVENTORIES = new HashMap<>();
+    private static final HashMap<UUID, TransmutationInventory> CLIENT_INVENTORIES = new HashMap<>();
 
     public static TransmutationInventory getTransmutationInventory(Player player)
     {
-        if(!INVENTORIES.containsKey(player.getUUID().toString()))
+        HashMap<UUID, TransmutationInventory> inventoriesMap = player.level().isClientSide() ? CLIENT_INVENTORIES : SERVER_INVENTORIES;
+        if(!inventoriesMap.containsKey(player.getUUID()))
         {
             TransmutationInventory transmutationInventory = new TransmutationInventory(player);
-            INVENTORIES.put(player.getUUID().toString(), transmutationInventory);
+            inventoriesMap.put(player.getUUID(), transmutationInventory);
         }
-        return INVENTORIES.get(player.getUUID().toString());
+        return inventoriesMap.get(player.getUUID());
     }
 
     public static void updateInventory(Player player, TransmutationInventory transmutationInventory)
     {
-        INVENTORIES.put(player.getUUID().toString(), transmutationInventory);
+        HashMap<UUID, TransmutationInventory> inventoriesMap = player.level().isClientSide() ? CLIENT_INVENTORIES : SERVER_INVENTORIES;
+        inventoriesMap.put(player.getUUID(), transmutationInventory);
     }
 
     public static NonNullList<ItemStack> getTransmutationContent(int page, String search, ItemStack emcTarget, Player player)
@@ -62,6 +66,7 @@ public class TransmutationTableHandler
 
     public static void clear()
     {
-        INVENTORIES.clear();
+        SERVER_INVENTORIES.clear();
+        CLIENT_INVENTORIES.clear();
     }
 }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/init/ModRecipes.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/init/ModRecipes.java
@@ -37,9 +37,17 @@ public class ModRecipes
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.DIRT.defaultBlockState(), Blocks.SAND.defaultBlockState(), Blocks.COBBLESTONE.defaultBlockState());
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.SAND.defaultBlockState(), Blocks.GRASS_BLOCK.defaultBlockState(), Blocks.COBBLESTONE.defaultBlockState());
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.GRAVEL.defaultBlockState(), Blocks.SANDSTONE.defaultBlockState(), null);
+        EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.SANDSTONE.defaultBlockState(), Blocks.GRAVEL.defaultBlockState(), null);
+
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.WATER.defaultBlockState(), Blocks.ICE.defaultBlockState(), null);
+        EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.ICE.defaultBlockState(), Blocks.WATER.defaultBlockState(), null);
+
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.LAVA.defaultBlockState(), Blocks.OBSIDIAN.defaultBlockState(), null);
+        EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.OBSIDIAN.defaultBlockState(), Blocks.LAVA.defaultBlockState(), null);
+
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.MELON.defaultBlockState(), Blocks.PUMPKIN.defaultBlockState(), null);
+        EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.PUMPKIN.defaultBlockState(), Blocks.MELON.defaultBlockState(), null);
+
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.GRANITE.defaultBlockState(), Blocks.DIORITE.defaultBlockState(), Blocks.ANDESITE.defaultBlockState());
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.DIORITE.defaultBlockState(), Blocks.ANDESITE.defaultBlockState(), Blocks.GRANITE.defaultBlockState());
         EquivalentExchangeAPI.registerInWorldTransmutationRecipe(Blocks.ANDESITE.defaultBlockState(), Blocks.GRANITE.defaultBlockState(), Blocks.DIORITE.defaultBlockState());

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
@@ -27,6 +27,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.util.Collections;
@@ -53,7 +54,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
         return InteractionResult.SUCCESS;
     }
 
-    public static BlockState getTransmutation(BlockState blockState, boolean sneaking)
+    public static @Nullable BlockState getTransmutation(BlockState blockState, boolean sneaking)
     {
         for (InWorldTransmutation inWorldTransmutationRecipe : EquivalentExchangeAPI.IN_WORLD_TRANSMUTATION_RECIPES)
         {
@@ -69,7 +70,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     {
         BlockState targeted = level.getBlockState(pos);
         boolean isSneaking = player.isShiftKeyDown();
-        BlockState result = getTransmutation(targeted, isSneaking);
+        @Nullable BlockState result = getTransmutation(targeted, isSneaking);
         if (result == null)
         {
             return Collections.emptyMap();
@@ -101,7 +102,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
             BlockState state = level.getBlockState(currentPos);
             if (state.is(targetBlock))
             {
-                BlockState actualResult;
+                @Nullable BlockState actualResult;
                 if (conversions.containsKey(state))
                 {
                     actualResult = conversions.get(state);

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
@@ -48,6 +48,12 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     }
 
     @Override
+    public boolean excludedFromOverlay(BlockState blockState)
+    {
+        return blockState.isAir();
+    }
+
+    @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand)
     {
         ItemStack itemstack = player.getItemInHand(hand);

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
@@ -8,13 +8,14 @@ import net.creeperhost.equivalentexchange.init.ModSounds;
 import net.creeperhost.equivalentexchange.items.interfaces.IActionItem;
 import net.creeperhost.equivalentexchange.items.interfaces.IChargeableItem;
 import net.creeperhost.equivalentexchange.items.interfaces.IOverlayItem;
+import net.creeperhost.polylib.helpers.VectorHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -22,10 +23,13 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.ClipContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,14 +48,32 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     }
 
     @Override
-    public InteractionResult useOn(UseOnContext useOnContext)
+    public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand)
     {
-        Level level = useOnContext.getLevel();
-        Player player = useOnContext.getPlayer();
-        if(player == null) return InteractionResult.FAIL;
-        ItemPhilosophersStone.getChanges(level, useOnContext.getClickedPos(), player, useOnContext.getClickedFace(), getCharge(useOnContext.getItemInHand())).forEach((blockPos, blockState) -> level.setBlock(blockPos, blockState, 3));
-        level.playSound(player, player.getX(), player.getY(), player.getZ(), ModSounds.TRANSMUTE.get(), SoundSource.PLAYERS, 1, 1);
-        return InteractionResult.SUCCESS;
+        ItemStack itemstack = player.getItemInHand(hand);
+
+        int hitRange = 5;
+        BlockHitResult hitResult = VectorHelper.getLookingAt(player, ClipContext.Fluid.SOURCE_ONLY, hitRange);
+
+        if (hitResult.getType() == HitResult.Type.BLOCK)
+        {
+            BlockPos targetPos = hitResult.getBlockPos();
+            Direction targetFace = hitResult.getDirection();
+            BlockState targetState = level.getBlockState(targetPos);
+
+            boolean isSneaking = player.isShiftKeyDown();
+            BlockState result = getTransmutation(targetState, isSneaking);
+
+            if (result == null) return InteractionResultHolder.pass(itemstack);
+            Map<BlockPos, BlockState> changes = getChanges(level, targetPos, player, targetFace, getCharge(itemstack));
+            changes.forEach((blockPos, blockState) -> level.setBlock(blockPos, blockState, 3));
+            level.playSound(player, player.getX(), player.getY(), player.getZ(), ModSounds.TRANSMUTE.get(), SoundSource.PLAYERS, 1, 1);
+            return InteractionResultHolder.success(itemstack);
+        }
+        // Quite possible, in the future, we might:
+        // else if (hitResult.getType() == HitResult.Type.ENTITY) {}
+        // else if (hitResult.getType() == HitResult.Type.MISS) {}
+        return InteractionResultHolder.pass(itemstack);
     }
 
     public static @Nullable BlockState getTransmutation(BlockState blockState, boolean sneaking)
@@ -97,12 +119,12 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
         Map<BlockPos, BlockState> changes = new HashMap<>();
         Block targetBlock = targeted.getBlock();
 
-        stream.forEach(currentPos ->
-        {
+        stream.forEach(currentPos -> {
             BlockState state = level.getBlockState(currentPos);
             if (state.is(targetBlock))
             {
-                @Nullable BlockState actualResult;
+                @Nullable
+                BlockState actualResult;
                 if (conversions.containsKey(state))
                 {
                     actualResult = conversions.get(state);
@@ -129,7 +151,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     @Override
     public void onActionKeyPressed(@NotNull ItemStack stack, @NotNull Player player, InteractionHand hand)
     {
-        if(!player.getCommandSenderWorld().isClientSide)
+        if (!player.getCommandSenderWorld().isClientSide)
         {
             player.openMenu(new ContainerProvider(stack));
         }
@@ -138,13 +160,15 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     @Override
     public void chargeKeyPressed(@NotNull ItemStack stack, @NotNull Player player, InteractionHand hand, boolean shiftKeyDown)
     {
-        if(!shiftKeyDown)
+        if (!shiftKeyDown)
         {
-            if(getCharge(stack) < maxCharge(stack)) setCharge(stack, getCharge(stack) + 1);
+            if (getCharge(stack) < maxCharge(stack))
+                setCharge(stack, getCharge(stack) + 1);
         }
         else
         {
-            if(getCharge(stack) > 0) setCharge(stack, getCharge(stack) - 1);
+            if (getCharge(stack) > 0)
+                setCharge(stack, getCharge(stack) - 1);
         }
     }
 
@@ -152,7 +176,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     public int getCharge(@NotNull ItemStack stack)
     {
         CompoundTag tag = stack.getOrCreateTag();
-        if(!tag.contains("charge"))
+        if (!tag.contains("charge"))
         {
             tag.putInt("charge", 0);
         }
@@ -196,8 +220,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
         return Color.WHITE;
     }
 
-    private record ContainerProvider(ItemStack stack) implements MenuProvider
-    {
+    private record ContainerProvider(ItemStack stack) implements MenuProvider {
         @NotNull
         @Override
         public AbstractContainerMenu createMenu(int windowId, @NotNull Inventory playerInventory, @NotNull Player player)

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/ItemPhilosophersStone.java
@@ -48,7 +48,7 @@ public class ItemPhilosophersStone extends Item implements IActionItem, IChargea
     }
 
     @Override
-    public boolean excludedFromOverlay(BlockState blockState)
+    public boolean blockIgnored(BlockState blockState)
     {
         return blockState.isAir();
     }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/interfaces/IOverlayItem.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/interfaces/IOverlayItem.java
@@ -11,5 +11,5 @@ public interface IOverlayItem
 
     Color getColour(ItemStack stack);
 
-    boolean excludedFromOverlay(BlockState block);
+    boolean blockIgnored(BlockState block);
 }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/interfaces/IOverlayItem.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/interfaces/IOverlayItem.java
@@ -1,6 +1,7 @@
 package net.creeperhost.equivalentexchange.items.interfaces;
 
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.awt.*;
 
@@ -9,4 +10,6 @@ public interface IOverlayItem
     int getRange(ItemStack stack);
 
     Color getColour(ItemStack stack);
+
+    boolean excludedFromOverlay(BlockState block);
 }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/tools/ItemDestructionCatalyst.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/tools/ItemDestructionCatalyst.java
@@ -20,6 +20,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,6 +35,16 @@ public class ItemDestructionCatalyst extends FuelUsingItem implements IOverlayIt
     public ItemDestructionCatalyst()
     {
         super(new Properties().stacksTo(1));
+    }
+
+    public boolean excludedFromOverlay(BlockState blockState)
+    {
+        return blockIgnored(blockState);
+    }
+
+    public static boolean blockIgnored(BlockState blockState)
+    {
+        return blockState.is(BlockTags.FEATURES_CANNOT_REPLACE) || blockState.is(Blocks.AIR) || blockState.is(Blocks.WATER) || blockState.is(Blocks.LAVA);
     }
 
     @Override
@@ -55,7 +66,7 @@ public class ItemDestructionCatalyst extends FuelUsingItem implements IOverlayIt
             for (BlockPos pos : positions)
             {
                 BlockState blockState = level.getBlockState(pos);
-                if (!blockState.is(BlockTags.FEATURES_CANNOT_REPLACE))
+                if (!blockIgnored(blockState))
                 {
                     drops.addAll(Block.getDrops(blockState, (ServerLevel) level, pos, null, player, useOnContext.getItemInHand()));
                     level.removeBlock(pos, false);
@@ -109,7 +120,7 @@ public class ItemDestructionCatalyst extends FuelUsingItem implements IOverlayIt
 
         stream.forEach(currentPos ->
         {
-            if(!level.getBlockState(currentPos).isAir())
+            if(!blockIgnored(level.getBlockState(currentPos)))
                 changes.put(currentPos.immutable(), level.getBlockState(currentPos));
         });
         return changes;

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/tools/ItemDestructionCatalyst.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/tools/ItemDestructionCatalyst.java
@@ -42,12 +42,12 @@ public class ItemDestructionCatalyst extends FuelUsingItem implements IOverlayIt
         super(new Properties().stacksTo(1));
     }
 
-    public boolean excludedFromOverlay(BlockState blockState)
+    public boolean blockIgnored(BlockState blockState)
     {
-        return blockIgnored(blockState);
+        return blockIgnoredStatic(blockState);
     }
 
-    public static boolean blockIgnored(BlockState blockState)
+    public static boolean blockIgnoredStatic(BlockState blockState)
     {
         return blockState.is(BlockTags.FEATURES_CANNOT_REPLACE) || blockState.is(Blocks.AIR) || blockState.is(Blocks.WATER) || blockState.is(Blocks.LAVA);
     }
@@ -130,7 +130,7 @@ public class ItemDestructionCatalyst extends FuelUsingItem implements IOverlayIt
 
         stream.forEach(currentPos ->
         {
-            if(!blockIgnored(level.getBlockState(currentPos))) changes.put(currentPos.immutable(), level.getBlockState(currentPos));
+            if(!blockIgnoredStatic(level.getBlockState(currentPos))) changes.put(currentPos.immutable(), level.getBlockState(currentPos));
         });
         return changes;
     }

--- a/common/src/main/java/net/creeperhost/equivalentexchange/items/tools/ItemDestructionCatalyst.java
+++ b/common/src/main/java/net/creeperhost/equivalentexchange/items/tools/ItemDestructionCatalyst.java
@@ -62,7 +62,7 @@ public class ItemDestructionCatalyst extends FuelUsingItem implements IOverlayIt
 
             int range = getRange(useOnContext.getItemInHand());
 
-            var positions = LevelHelper.getPositionsFromBox(LevelHelper.getAABBbox(blockPos, direction, --range));
+            var positions = LevelHelper.getPositionsFromBox(LevelHelper.getAABBbox(blockPos, direction, range--));
             for (BlockPos pos : positions)
             {
                 BlockState blockState = level.getBlockState(pos);


### PR DESCRIPTION
- _Issue_
  - _Solution_
---
- When in-world transmutation recipe gives null, `onHudRender()` crashes the game. Example: sneak and look at gravel with philosopher stone.
  - Added null check
- In singleplayer, transmutation tables' `INVENTORIES` HashMap was shared between the threads of client and server. It lead to collisions and broke the transmutation table randomly. Had to re-enter the world to fix it.
  - Split that hashmap into two separate hashmaps for client and server
- Philosopher's Stone couldn't work with fluids properly.
  - Fix targeting. Replaced useOn() with use().
  - Adjusted P.S. overlay render over water and ice (blocks were going invisible otherwise)
- Few in-world transmutation recipes were missing (?): there was gravel>sandstone, but not sandstone>gravel.
  - Added missing in-world transmutation recipes. **Mod authors might wanna check this and possibly cut out.**
- Destruction Catalyst's block overlay render doesn't ignore water or lava.
  - D.C.'s block overlay now omits water and lava block, just like air. Both overlay and usage now depend on `IOverlayItem.blockIgnored[Static]`.
- D.C. at Range=Charge=0 destroys two layers: the targeted one + the one on the side which the player hits. Range = N>=1 renders N+1 layer overlay but destroys N layers.
  - `--range` -> `range--`
- D.C. overlay ignored grass and such, but useOn() didn't, rendering the overlay misleading to the player.
  - Fix targeting. Replaced useOn() with use().
---
P.S. Made atomic commits to make it easier for you to redact parts if needed. Guess you'll squash the commits